### PR TITLE
bugfix: incorrect focus for text fields upon opening editor objects.

### DIFF
--- a/src/renderer/components/layout/ConnectedCharacterEditor.tsx
+++ b/src/renderer/components/layout/ConnectedCharacterEditor.tsx
@@ -33,10 +33,12 @@ export const ConnectedCharacterEditor: React.FC<
         setAutosaveStatus: setGlobalAutosaveStatus,
         setAutosaveError: setGlobalAutosaveError,
         setActiveDocument,
+        consumePendingTitleFocus,
     } = useAppStore();
 
     const [autosaveStatus, setAutosaveStatus] =
         React.useState<AutosaveStatus>("idle");
+    const [focusTitleOnMount, setFocusTitleOnMount] = React.useState(false);
 
     const isActiveEditor =
         activeDocument?.kind === "character" &&
@@ -47,6 +49,18 @@ export const ConnectedCharacterEditor: React.FC<
             setGlobalAutosaveStatus(autosaveStatus);
         }
     }, [isActiveEditor, autosaveStatus, setGlobalAutosaveStatus]);
+
+    React.useEffect(() => {
+        if (!isActiveEditor) {
+            return;
+        }
+
+        if (
+            consumePendingTitleFocus({ kind: "character", id: characterId })
+        ) {
+            setFocusTitleOnMount(true);
+        }
+    }, [characterId, consumePendingTitleFocus, isActiveEditor]);
 
     const character = React.useMemo(
         () => characters.find((c) => c.id === characterId),
@@ -304,6 +318,7 @@ export const ConnectedCharacterEditor: React.FC<
             onGeneratePlaylist={handleGeneratePlaylist}
             onImportPlaylist={handleImportPlaylist}
             onNavigateToDocument={handleNavigateToDocument}
+            focusTitleOnMount={focusTitleOnMount}
         />
     );
 };

--- a/src/renderer/components/layout/ConnectedLocationEditor.tsx
+++ b/src/renderer/components/layout/ConnectedLocationEditor.tsx
@@ -33,10 +33,12 @@ export const ConnectedLocationEditor: React.FC<
         setAutosaveStatus: setGlobalAutosaveStatus,
         setAutosaveError: setGlobalAutosaveError,
         setActiveDocument,
+        consumePendingTitleFocus,
     } = useAppStore();
 
     const [autosaveStatus, setAutosaveStatus] =
         React.useState<AutosaveStatus>("idle");
+    const [focusTitleOnMount, setFocusTitleOnMount] = React.useState(false);
 
     const isActiveEditor =
         activeDocument?.kind === "location" && activeDocument.id === locationId;
@@ -46,6 +48,16 @@ export const ConnectedLocationEditor: React.FC<
             setGlobalAutosaveStatus(autosaveStatus);
         }
     }, [isActiveEditor, autosaveStatus, setGlobalAutosaveStatus]);
+
+    React.useEffect(() => {
+        if (!isActiveEditor) {
+            return;
+        }
+
+        if (consumePendingTitleFocus({ kind: "location", id: locationId })) {
+            setFocusTitleOnMount(true);
+        }
+    }, [consumePendingTitleFocus, isActiveEditor, locationId]);
 
     const location = React.useMemo(
         () => locations.find((l) => l.id === locationId),
@@ -292,6 +304,7 @@ export const ConnectedLocationEditor: React.FC<
             onGeneratePlaylist={handleGeneratePlaylist}
             onImportPlaylist={handleImportPlaylist}
             onNavigateToDocument={handleNavigateToDocument}
+            focusTitleOnMount={focusTitleOnMount}
         />
     );
 };

--- a/src/renderer/components/layout/ConnectedOrganizationEditor.tsx
+++ b/src/renderer/components/layout/ConnectedOrganizationEditor.tsx
@@ -33,10 +33,12 @@ export const ConnectedOrganizationEditor: React.FC<
         setActiveDocument,
         setAutosaveStatus: setGlobalAutosaveStatus,
         setAutosaveError: setGlobalAutosaveError,
+        consumePendingTitleFocus,
     } = useAppStore();
 
     const [autosaveStatus, setAutosaveStatus] =
         React.useState<AutosaveStatus>("idle");
+    const [focusTitleOnMount, setFocusTitleOnMount] = React.useState(false);
 
     const isActiveEditor =
         activeDocument?.kind === "organization" &&
@@ -47,6 +49,21 @@ export const ConnectedOrganizationEditor: React.FC<
             setGlobalAutosaveStatus(autosaveStatus);
         }
     }, [isActiveEditor, autosaveStatus, setGlobalAutosaveStatus]);
+
+    React.useEffect(() => {
+        if (!isActiveEditor) {
+            return;
+        }
+
+        if (
+            consumePendingTitleFocus({
+                kind: "organization",
+                id: organizationId,
+            })
+        ) {
+            setFocusTitleOnMount(true);
+        }
+    }, [consumePendingTitleFocus, isActiveEditor, organizationId]);
 
     const organization = React.useMemo(
         () => organizations.find((o) => o.id === organizationId),
@@ -292,6 +309,7 @@ export const ConnectedOrganizationEditor: React.FC<
             onImportSong={handleImportSong}
             onGeneratePlaylist={handleGeneratePlaylist}
             onImportPlaylist={handleImportPlaylist}
+            focusTitleOnMount={focusTitleOnMount}
         />
     );
 };

--- a/src/renderer/components/workspace/CharacterEditor.tsx
+++ b/src/renderer/components/workspace/CharacterEditor.tsx
@@ -53,6 +53,7 @@ export type CharacterEditorProps = {
     onImportPlaylist: (file: File) => Promise<void>;
     /** Navigate to a referenced document */
     onNavigateToDocument?: (ref: DocumentRef) => void;
+    focusTitleOnMount?: boolean;
 };
 
 const defaultValues = (
@@ -87,6 +88,7 @@ export const CharacterEditor: React.FC<CharacterEditorProps> = ({
     onGeneratePlaylist,
     onImportPlaylist,
     onNavigateToDocument,
+    focusTitleOnMount = false,
 }) => {
     const [values, setValues] = React.useState<CharacterEditorValues>(() =>
         defaultValues(character),
@@ -99,6 +101,7 @@ export const CharacterEditor: React.FC<CharacterEditorProps> = ({
     const fileInputRef = React.useRef<HTMLInputElement>(null);
     const songInputRef = React.useRef<HTMLInputElement>(null);
     const playlistInputRef = React.useRef<HTMLInputElement>(null);
+    const titleInputRef = React.useRef<HTMLInputElement>(null);
     const isUserChange = React.useRef(false);
 
     const toFriendlyError = React.useCallback(
@@ -112,6 +115,17 @@ export const CharacterEditor: React.FC<CharacterEditorProps> = ({
         setValues(defaultValues(character));
         setError(null);
     }, [character]);
+
+    React.useEffect(() => {
+        if (!focusTitleOnMount) {
+            return;
+        }
+
+        requestAnimationFrame(() => {
+            titleInputRef.current?.focus();
+            titleInputRef.current?.select();
+        });
+    }, [focusTitleOnMount]);
 
     React.useEffect(() => {
         if (!gallerySources.length) {
@@ -348,6 +362,7 @@ export const CharacterEditor: React.FC<CharacterEditorProps> = ({
                     <div className="entity-header-title">
                         <p className="panel-label">Character</p>
                         <input
+                            ref={titleInputRef}
                             type="text"
                             className="entity-name-input"
                             value={values.name}

--- a/src/renderer/components/workspace/LocationEditor.tsx
+++ b/src/renderer/components/workspace/LocationEditor.tsx
@@ -37,6 +37,7 @@ export type LocationEditorProps = {
     onImportPlaylist: (file: File) => Promise<void>;
     /** Navigate to a referenced document */
     onNavigateToDocument?: (ref: DocumentRef) => void;
+    focusTitleOnMount?: boolean;
 };
 
 const defaultValues = (location: WorkspaceLocation): LocationEditorValues => ({
@@ -61,6 +62,7 @@ export const LocationEditor: React.FC<LocationEditorProps> = ({
     onGeneratePlaylist,
     onImportPlaylist,
     onNavigateToDocument,
+    focusTitleOnMount = false,
 }) => {
     const [values, setValues] = React.useState<LocationEditorValues>(() =>
         defaultValues(location),
@@ -73,6 +75,7 @@ export const LocationEditor: React.FC<LocationEditorProps> = ({
     const fileInputRef = React.useRef<HTMLInputElement>(null);
     const songInputRef = React.useRef<HTMLInputElement>(null);
     const playlistInputRef = React.useRef<HTMLInputElement>(null);
+    const titleInputRef = React.useRef<HTMLInputElement>(null);
     const isUserChange = React.useRef(false);
 
     const toFriendlyError = React.useCallback(
@@ -86,6 +89,17 @@ export const LocationEditor: React.FC<LocationEditorProps> = ({
         setValues(defaultValues(location));
         setError(null);
     }, [location]);
+
+    React.useEffect(() => {
+        if (!focusTitleOnMount) {
+            return;
+        }
+
+        requestAnimationFrame(() => {
+            titleInputRef.current?.focus();
+            titleInputRef.current?.select();
+        });
+    }, [focusTitleOnMount]);
 
     React.useEffect(() => {
         if (!gallerySources.length) {
@@ -301,6 +315,7 @@ export const LocationEditor: React.FC<LocationEditorProps> = ({
                     <div className="entity-header-title">
                         <p className="panel-label">Location</p>
                         <input
+                            ref={titleInputRef}
                             type="text"
                             className="entity-name-input"
                             value={values.name}

--- a/src/renderer/components/workspace/OrganizationEditor.tsx
+++ b/src/renderer/components/workspace/OrganizationEditor.tsx
@@ -38,6 +38,7 @@ export type OrganizationEditorProps = {
     onImportSong: (file: File) => Promise<void>;
     onGeneratePlaylist: () => Promise<void>;
     onImportPlaylist: (file: File) => Promise<void>;
+    focusTitleOnMount?: boolean;
 };
 
 const defaultValues = (
@@ -68,6 +69,7 @@ export const OrganizationEditor: React.FC<OrganizationEditorProps> = ({
     onImportSong,
     onGeneratePlaylist,
     onImportPlaylist,
+    focusTitleOnMount = false,
 }) => {
     const [values, setValues] = React.useState<OrganizationEditorValues>(() =>
         defaultValues(organization),
@@ -80,6 +82,7 @@ export const OrganizationEditor: React.FC<OrganizationEditorProps> = ({
     const fileInputRef = React.useRef<HTMLInputElement>(null);
     const songInputRef = React.useRef<HTMLInputElement>(null);
     const playlistInputRef = React.useRef<HTMLInputElement>(null);
+    const titleInputRef = React.useRef<HTMLInputElement>(null);
     const isUserChange = React.useRef(false);
 
     const toFriendlyError = React.useCallback(
@@ -93,6 +96,17 @@ export const OrganizationEditor: React.FC<OrganizationEditorProps> = ({
         setValues(defaultValues(organization));
         setError(null);
     }, [organization]);
+
+    React.useEffect(() => {
+        if (!focusTitleOnMount) {
+            return;
+        }
+
+        requestAnimationFrame(() => {
+            titleInputRef.current?.focus();
+            titleInputRef.current?.select();
+        });
+    }, [focusTitleOnMount]);
 
     React.useEffect(() => {
         if (!gallerySources.length) {
@@ -318,6 +332,7 @@ export const OrganizationEditor: React.FC<OrganizationEditorProps> = ({
                     <div className="entity-header-title">
                         <p className="panel-label">Organization</p>
                         <input
+                            ref={titleInputRef}
                             type="text"
                             className="entity-name-input"
                             value={values.name}

--- a/src/renderer/state/appStore.ts
+++ b/src/renderer/state/appStore.ts
@@ -392,6 +392,8 @@ type AppStore = {
     setDraggedDocument: (
         doc: { id: string; kind: string; title: string } | null,
     ) => void;
+    pendingTitleFocusDocument: WorkspaceDocumentRef | null;
+    consumePendingTitleFocus: (selection: WorkspaceDocumentRef) => boolean;
     renamingDocument: { id: string; kind: string } | null;
     setRenamingDocument: (doc: { id: string; kind: string } | null) => void;
     closeProject: () => void;
@@ -495,6 +497,7 @@ export const useAppStore = create<AppStore>((set, get) => {
         | "pendingEditsByChapterId"
         | "pendingEditsById"
         | "archivedEditsById"
+        | "pendingTitleFocusDocument"
     > => ({
         projectId: "",
         activeProjectName: "",
@@ -518,6 +521,7 @@ export const useAppStore = create<AppStore>((set, get) => {
         pendingEditsByChapterId: {},
         pendingEditsById: {},
         archivedEditsById: {},
+        pendingTitleFocusDocument: null,
     });
 
     const applyUnauthenticatedState = () => {
@@ -1525,6 +1529,7 @@ export const useAppStore = create<AppStore>((set, get) => {
                     characters: nextCharacters,
                     activeDocument: nextTab,
                     openTabs: nextTabs,
+                    pendingTitleFocusDocument: nextTab,
                 };
             });
 
@@ -1598,6 +1603,7 @@ export const useAppStore = create<AppStore>((set, get) => {
                     locations: nextLocations,
                     activeDocument: nextTab,
                     openTabs: nextTabs,
+                    pendingTitleFocusDocument: nextTab,
                 };
             });
 
@@ -1670,6 +1676,7 @@ export const useAppStore = create<AppStore>((set, get) => {
                     organizations: nextOrganizations,
                     activeDocument: nextTab,
                     openTabs: nextTabs,
+                    pendingTitleFocusDocument: nextTab,
                 };
             });
 
@@ -2209,6 +2216,19 @@ export const useAppStore = create<AppStore>((set, get) => {
             set({ currentSelection: selection }),
         setDraggedDocument: (doc) => {
             set({ draggedDocument: doc });
+        },
+        pendingTitleFocusDocument: null,
+        consumePendingTitleFocus: (selection) => {
+            const pending = get().pendingTitleFocusDocument;
+            if (
+                pending &&
+                pending.kind === selection.kind &&
+                pending.id === selection.id
+            ) {
+                set({ pendingTitleFocusDocument: null });
+                return true;
+            }
+            return false;
         },
         renamingDocument: null,
         setRenamingDocument: (doc) => set({ renamingDocument: doc }),

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1630,11 +1630,12 @@ html {
 }
 
 .project-grid {
-    display: flex;
-    flex-wrap: wrap;
-    column-gap: 1.25rem;
+    display: grid;
+    column-gap: 0;
     row-gap: 1.75rem;
     margin-top: 1rem;
+    grid-template-columns: repeat(auto-fill, 200px);
+    justify-content: space-between;
 }
 
 .import-progress-bar {

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -902,7 +902,7 @@ export const SettingsView: React.FC = () => {
                                             <Button
                                                 onClick={handleUpdateEmail}
                                                 variant="primary"
-                                                style={{ width: "150px" }}
+                                                style={{ width: "180px" }}
                                                 disabled={
                                                     !user || isSubmittingAccount
                                                 }
@@ -932,7 +932,7 @@ export const SettingsView: React.FC = () => {
                                             <Button
                                                 onClick={handleUpdatePassword}
                                                 variant="primary"
-                                                style={{ width: "150px" }}
+                                                style={{ width: "180px" }}
                                                 disabled={
                                                     !user || isSubmittingAccount
                                                 }


### PR DESCRIPTION
bugfix: incorrect focus for text fields upon opening editor objects (……qol sorta). useful because ppl typically want to name their character first lol. feat: revamp of project-grid from flex to grid for better sizing. used to look trash and didn't distribute to the edges. 

+ future issue maybe, in the giga niche case where there's a vertical screen, gap between proj cards in grid is too too big.

Closes https://github.com/enxilium/inkline/issues/52